### PR TITLE
Schema validation improvements on the error messages and better React lifecyle integration

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import { Chart } from './chart';
-import { ValidatorResult } from './chart-validator';
+import { ChartValidator, ValidatorResult } from './chart-validator';
 
 /**
  * Create a container to visualize a GeoChart in a standalone manner.
@@ -38,37 +38,12 @@ export function App(): JSX.Element {
    */
   const handleError = (dataErrors: ValidatorResult, optionsErrors: ValidatorResult) => {
     // Gather all error messages
-    let msgData = '';
-    dataErrors.errors?.forEach((m: string) => {
-      msgData += `${m}\n`;
-    });
-
-    // Gather all error messages
-    let msgOptions = '';
-    optionsErrors.errors?.forEach((m: string) => {
-      msgOptions += `${m}\n`;
-    });
+    const msgAll = ChartValidator.parseValidatorResultsMessages([dataErrors, optionsErrors]);
 
     // Show the error (actually, can't because the snackbar is linked to a map at the moment and geochart is standalone)
     // TODO: Decide if we want the snackbar outside of a map or not and use showError or not
-    cgpv.api.utilities.showError('', msgData);
-    cgpv.api.utilities.showError('', msgOptions);
-    console.error(dataErrors.errors, optionsErrors.errors);
-    alert('There was an error parsing the Chart inputs. View console for details.');
-  };
-
-  /**
-   * Handles when the Chart X Axis has changed.
-   */
-  const handleChartXAxisChanged = () => {
-    console.log('Handle Chart X Axis');
-  };
-
-  /**
-   * Handles when the Chart Y Axis has changed.
-   */
-  const handleChartYAxisChanged = () => {
-    console.log('Handle Chart Y Axis');
+    cgpv.api.utilities.showError('', msgAll);
+    alert(`There was an error parsing the Chart inputs.\n\n${msgAll}\n\nView console for details.`);
   };
 
   // Effect hook to add and remove event listeners
@@ -80,16 +55,7 @@ export function App(): JSX.Element {
   });
 
   // Render the Chart
-  return (
-    <Chart
-      style={{ width: 800 }}
-      data={data}
-      options={options}
-      handleSliderXChanged={handleChartXAxisChanged}
-      handleSliderYChanged={handleChartYAxisChanged}
-      handleError={handleError}
-    />
-  );
+  return <Chart style={{ width: 800 }} data={data} options={options} handleError={handleError} />;
 }
 
 export default App;

--- a/src/chart-validator.ts
+++ b/src/chart-validator.ts
@@ -4,6 +4,7 @@ import Ajv from 'ajv';
  * Represents the result of a Chart data or options inputs validations.
  */
 export type ValidatorResult = {
+  param: string;
   valid: boolean;
   errors?: string[];
 };
@@ -145,9 +146,11 @@ export class ChartValidator {
     // Validate
     const valid = validate(data) as boolean;
     return {
+      param: 'data',
       valid,
       errors: validate.errors?.map((e: Ajv.ErrorObject) => {
-        return e.message || 'generic schema error';
+        const m = e.message || 'generic schema error';
+        return `${e.schemaPath} | ${e.keyword} | ${m}`;
       }),
     };
   };
@@ -162,10 +165,31 @@ export class ChartValidator {
     // Validate
     const valid = validate(options) as boolean;
     return {
+      param: 'options',
       valid,
       errors: validate.errors?.map((e: Ajv.ErrorObject) => {
-        return e.message || 'generic schema error';
+        const m = e.message || 'generic schema error';
+        return `${e.schemaPath} | ${e.keyword} | ${m}`;
       }),
     };
   };
+
+  public static parseValidatorResultsMessages(valRes: ValidatorResult[]) {
+    // Gather all error messages for data input
+    let msg = '';
+    valRes.forEach((v) => {
+      // Redirect
+      msg += ChartValidator.parseValidatorResultMessage(v);
+    });
+    return msg.replace(/^\n+|\n+$/gm, '');
+  }
+
+  public static parseValidatorResultMessage(valRes: ValidatorResult) {
+    // Gather all error messages for data input
+    let msg = '';
+    valRes.errors?.forEach((m: string) => {
+      msg += `${m}\n`;
+    });
+    return msg.replace(/^\n+|\n+$/gm, '');
+  }
 }


### PR DESCRIPTION
Improved the validator error messaging when validating schemas.

Using schemaPath instead of dataPath, because sometimes dataPath is not set and using instancePath which isn't even a valid property in Ajv. This seems like an issue with Ajv to me at this stage. Anyways, this works for now too with the time investment allowed.

Making sure to raise the handleError via the useEffect handle so that the listener can trigger a state change on another component freely, without React throwing a warning in console.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geochart/36)
<!-- Reviewable:end -->
