### PR TITLE
Scale option for Y Axis

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,6 +41,12 @@
     "import/prefer-default-export": "off",
     "react/no-find-dom-node": 0,
     "class-methods-use-this": "off",
+    "@typescript-eslint/class-methods-use-this": [
+      1, // Warning
+      {
+        "ignoreOverrideMethods": true
+      }
+    ],
     "jsx-a11y/anchor-is-valid": [
       "error",
       {
@@ -73,14 +79,30 @@
       {
         "endOfLine": "auto"
       }
-    ]
+    ],
+    "no-restricted-syntax": [
+      1, // Warning
+      {
+          "selector": ":matches(PropertyDefinition, MethodDefinition)[accessibility='private']",
+          "message": "Use # prefix for private instead"
+      }
+    ],
+    "require-await": 1, // Warning
+    "@typescript-eslint/await-thenable": "warn"
   },
   "overrides": [
     {
       // enable the rule specifically for TypeScript files
       "files": ["*.ts", "*.mts", "*.cts", "*.tsx"],
       "rules": {
-        "@typescript-eslint/explicit-function-return-type": "error"
+        "@typescript-eslint/no-floating-promises": 1, // Warning
+        "@typescript-eslint/no-misused-promises": 1, // Warning
+        "@typescript-eslint/explicit-function-return-type": [
+          1,
+          {
+            "allowExpressions": true
+          }
+        ]
       }
     }
   ]

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
             step: 0.1
           },
           stepsSwitcher: true,
+          scaleSwitcher: true,
           resetStates: true,
           description: 'This is a description text',
           download: true
@@ -729,7 +730,7 @@
   </head>
 
   <body>
-    <div style="text-align: center; height: 400px;">
+    <div style="text-align: center; height: 440px;">
       <div style="display:inline-block; background-color: lightgreen; width: 49%; height: 100%; vertical-align:top;">
         <div style="text-align: left;">
           GEOCHART INPUTS <span style="font-size: small;">(these parameters will be parsed and sent to the Chart.js props on the right and GeoChart created below)</span>

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -2,6 +2,7 @@
   "geochart": {
     "feature": "Feature",
     "steps": "Steps",
+    "scale": "Scale",
     "category": "Category",
     "parsingError": "There was an error parsing the Chart inputs.",
     "viewConsoleDetails": "View console for details.",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -2,6 +2,7 @@
   "geochart": {
     "feature": "Enregistrement",
     "steps": "Marches",
+    "scale": "Échelle",
     "category": "Catégorie",
     "parsingError": "Une erreur est survenue lors de la lecture des paramètres.",
     "viewConsoleDetails": "Voir détails dans la console.",

--- a/src/chart-parsing.ts
+++ b/src/chart-parsing.ts
@@ -9,6 +9,7 @@ import {
   GeoChartQueryOptionClause,
   GeoChartSelectedDataset,
   StepsPossibilities,
+  ScalePossibilities,
   DEFAULT_COLOR_PALETTE_CUSTOM_TRANSPARENT,
   DEFAULT_COLOR_PALETTE_CUSTOM_OPAQUE,
   DEFAULT_COLOR_PALETTE_CUSTOM_ALT_TRANSPARENT,
@@ -611,6 +612,7 @@ export function setColorPalettes<TType extends ChartType>(chartConfig: GeoChartC
 export function createChartJSOptions<TType extends ChartType>(
   chartConfig: GeoChartConfig<TType>,
   defaultOptions: ChartOptions<TType>,
+  yAxisType: ScalePossibilities,
   language: string
 ): ChartOptions<TType> {
   // The Chart JS Options as entered or the default options
@@ -664,11 +666,11 @@ export function createChartJSOptions<TType extends ChartType>(
   if (chartConfig.chart === 'line' || chartConfig.chart === 'bar') {
     const optionsLine = options as ChartOptions<'line' | 'bar'>;
     // If type is set
-    if (chartConfig.geochart.yAxis?.type) {
+    if (yAxisType) {
       optionsLine.scales = {
         ...optionsLine.scales,
         y: {
-          type: chartConfig.geochart.yAxis?.type,
+          type: yAxisType,
         },
       };
     }

--- a/src/chart-style.ts
+++ b/src/chart-style.ts
@@ -33,6 +33,14 @@ export const getSxClasses = (theme: Theme) => {
       '& .MuiSelect-select': {
         padding: '8px 12px !important',
       },
+      marginRight: '10px',
+    },
+    uiOptionsScaleSelector: {
+      minWidth: '130px',
+      '& .MuiSelect-select': {
+        padding: '8px 12px !important',
+      },
+      marginRight: '10px',
     },
     downloadButton: {
       marginLeft: 'auto',

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,9 @@ export type GeoChartCategory = {
 export const StepsPossibilitiesConst = ['before', 'after', 'middle', false] as const;
 export type StepsPossibilities = (typeof StepsPossibilitiesConst)[number];
 
+export const ScalePossibilitiesConst = ['linear', 'logarithmic'] as const;
+export type ScalePossibilities = (typeof ScalePossibilitiesConst)[number];
+
 /**
  * The Configuration about using GeoChart specific parameters.
  */
@@ -90,6 +93,7 @@ export type GeoChartOptionsUI = {
   xSlider?: GeoChartOptionsSlider;
   ySlider?: GeoChartOptionsSlider;
   stepsSwitcher?: boolean;
+  scaleSwitcher?: boolean;
   resetStates?: boolean;
   description?: string;
   download?: boolean;


### PR DESCRIPTION
Adds a drop down option for the y scale (linear or logarithmic).
Updated the ESLint rules based on the updated standards.

Adds support for issue in GeoView: [#2247](https://github.com/Canadian-Geospatial-Platform/geoview/issues/2247)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geochart/76)
<!-- Reviewable:end -->
