### PR TITLE
Aligning the GeoChartDefaultColors type with expectations from geoview-geochart

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -148,9 +148,9 @@ export type GeoChartCategoryGroup<TData> = {
  * The default colors to assign to the chart.
  */
 export type GeoChartDefaultColors = {
-  backgroundColor: string;
-  borderColor: string;
-  color: string;
+  backgroundColor?: string;
+  borderColor?: string;
+  color?: string;
 };
 
 /**


### PR DESCRIPTION
Aligning the GeoChartDefaultColors type with expectations from geoview-geochart

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Canadian-Geospatial-Platform/geochart/127)
<!-- Reviewable:end -->
